### PR TITLE
Fixed joke formatting when displayed on myJokes page

### DIFF
--- a/assets/js/gamepage.js
+++ b/assets/js/gamepage.js
@@ -35,13 +35,18 @@ var score = 0;
       score +=10;
       getJoke().then( function(data) {
         if (data.type = 'single' && data.joke) {
-          console.log(data.joke);
+
           jokeBoxEl.html( data.joke );
-          currentJoke = data.joke;
+
+          // save joke as object with type 1 and unique id
+          currentJoke = { type: 1, id: data.id, joke: data.joke };
+
         } else {
-          console.log(data.setup + data.delivery)
+
           jokeBoxEl.html( `<p>${data.setup}</p><p>${data.delivery}</p>` );
-          currentJoke = data.setup + data.delivery;
+
+          // save joke as object with type 2 and unique id
+          currentJoke = { type: 2, id: data.id, setup: data.setup, delivery: data.delivery };
         }
         hilariousEl.on('click', function(event) {
           event.preventDefault();

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -36,8 +36,15 @@ var myJokes= [];
 
 // save jokes to local storage
 function saveJoke(){
+
+  // if joke is already saved return out of function
+  var jokeIndex = myJokes.findIndex( jokes => jokes.id === currentJoke.id );
+  if ( jokeIndex >= 0 ) return;
+
+  // push current joke to joke array and save to local storage
   myJokes.push(currentJoke);
   localStorage.setItem("jokes", JSON.stringify(myJokes));
+
 }
 
 // load jokes from local storage
@@ -72,7 +79,7 @@ function initialize () {
   }
 
   if ( themeIndex !== null ) {
-    console.log( 'hello' )
+
     // if there is a them selected add highlight to selected theme card
     userModal.children().children().children( 'img' ).eq( themeIndex ).addClass( 'selected-theme' );
     themeDisplayEl.attr( 'src',  themes[ themeIndex ] );
@@ -102,7 +109,6 @@ function initialize () {
 
 function changeTheme () {
 
-  console.log( themeIndex)
   if ( themeIndex > 0 ) {
 
      documentRootEl.css( '--cardThemeUrl', `url( '../.${ themes[ themeIndex ] }' )` );

--- a/assets/js/myjokes.js
+++ b/assets/js/myjokes.js
@@ -1,8 +1,5 @@
 //Get Jokes from Local Storage
 
-myJokes =  localStorage.getItem('jokes') || "[]";
-myJokes = JSON.parse(myJokes);
-
 var rootEl = $('#joke-container');
 
 var rowEl = $('<div>');
@@ -56,6 +53,7 @@ for (var iter = 0; iter < myJokes.length; iter++) {
     spanRevealEl.append(iconRevealEl);
 
     var jokeContentEl = $('<p>');
-    jokeContentEl.text(myJokes[iter]);
+    if ( myJokes[iter].type === 1 ) jokeContentEl.text(myJokes[iter].joke);
+    if ( myJokes[iter].type === 2 ) jokeContentEl.html( `<p>${ myJokes[iter].setup }</p><p>${ myJokes[iter].delivery }</p>` )
     cardRevealEl.append(jokeContentEl);
 }


### PR DESCRIPTION
Jokes are now saved as an Object with a unique id recieved from the API. 
The myJokes page now displays two part jokes on seperate lines.
The saveJoke function now uses the id to find if the joke exsists in the myJokes array and doesn't save if it already exsists preventing duplicate jokes from being saved